### PR TITLE
[Closes #15] CS team lead plugin

### DIFF
--- a/scripts/cs-team-lead.coffee
+++ b/scripts/cs-team-lead.coffee
@@ -1,0 +1,30 @@
+# Description:
+#   Set the CS team leads and update room topic
+#
+# Commands:
+#   hubot today's team leads are <name, name> - Set the leads and room topic
+#   hubot who are today's leads?              - Get the leads for the day
+#
+# Examples:
+#   hubot today's team leads are Steve, Jackie, Mike
+#   hubot who are today's lead?
+#
+# Author:
+#   doomspork
+
+_ = require 'underscore'
+
+module.exports = (robot) ->
+  CS_LEADS_KEY = 'cs_team'
+
+  robot.respond /today's (?:team\s?)?leads are (\w+(?:,\s?\w+)?)/i, (msg) ->
+    peeps = msg.match[1].split ','
+    peeps = _.map(peeps, (person) -> person.trim())
+    robot.brain.set CS_LEADS_KEY, peeps
+    msg.topic "Leads are #{peeps.join ', '}"
+    msg.send  "Current leads are #{peeps.join ', '}"
+
+  robot.respond /who are today's leads/i, (msg) ->
+    peeps = robot.brain.get CS_LEADS_KEY
+    msg.send "Current leads are #{peeps.join ', '}"
+


### PR DESCRIPTION
Pinging for review:  @jcarouth, @jmacadam, or @amdtech.

Apparently CS has this manual process of looking up daily team leads and announcing it to the room, let's start letting Jarvis handle part of that.  This is also super simple script we could modify in future Ski Schools.

Tagging @ryanwaters since we had discussed this: This example hits a few of the standard Hubot features like `#topic`,`#send`, and the use of the brain.  Doesn't need to be overly complicated or worry about APIs, most of what is necessary is already available either on `robot` or the `msg` object.

Potential future features:
- Use a room announcement (requires: #4)
- Support beyond today
- Remote data source
