### PR TITLE
Don't overwrite the brain when loading from mongo

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -10,7 +10,6 @@
   "hello.coffee",
   "kittens.coffee",
   "lolz.coffee",
-  "mongo-brain.coffee",
   "pagerduty.coffee",
   "shipit.coffee",
   "snow.coffee",
@@ -18,4 +17,4 @@
   "twitter.coffee",
   "wat.coffee",
   "whoisout.coffee"
-  ]
+]

--- a/scripts/mongo-brain.coffee
+++ b/scripts/mongo-brain.coffee
@@ -1,0 +1,71 @@
+# Description:
+#  Enhances hubot-brain with MongoDB. Useful for Heroku accounts that want
+#  better persistance. Falls back to memory brain if Mongo connection fails
+#  for local testing.
+#
+# Dependencies:
+#   "mongodb": ">= 1.2.0"
+#
+# Configuration:
+#   MONGODB_USERNAME
+#   MONGODB_PASSWORD
+#   MONGODB_HOST
+#   MONGODB_PORT
+#   MONGODB_DB
+#
+# Commands:
+#   None
+#
+# Author:
+#   ajacksified, maxbeatty
+
+Util = require "util"
+mongodb = require "mongodb"
+Server = mongodb.Server
+Collection = mongodb.Collection
+Db = mongodb.Db
+
+module.exports = (robot) ->
+  user = process.env.MONGODB_USERNAME || "admin"
+  pass = process.env.MONGODB_PASSWORD || "password"
+  host = process.env.MONGODB_HOST || "localhost"
+  port = process.env.MONGODB_PORT || "27017"
+  dbname = process.env.MONGODB_DB || "hubot"
+
+  error = (err) ->
+    console.log "==MONGO BRAIN UNAVAILABLE==\n==SWITCHING TO MEMORY BRAIN=="
+    console.log err
+
+  server = new Server host, port, {}
+  db = new Db dbname, server, { w: 1, native_parser: true }
+
+  db.open (err, client) ->
+    return error err if err
+
+    robot.logger.debug 'Successfully opened connection to mongo'
+
+    db.authenticate user, pass, (err, success) ->
+      return error err if err
+
+      robot.logger.debug 'Successfully authenticated with mongo'
+
+      collection = new Collection client, 'hubot_storage'
+
+      collection.find().limit(1).toArray (err, results) ->
+        return error err if err
+
+        robot.logger.debug 'Successfully queried mongo'
+        robot.logger.debug Util.inspect(results, false, 4)
+
+        if results.length > 0
+          robot.brain.mergeData results[0]
+          robot.brain.emit 'loaded', results[0]
+        else
+          robot.logger.debug 'No results found'
+
+      robot.brain.on 'save', (data) ->
+        robot.logger.debug 'Save event caught by mongo'
+        robot.logger.debug Util.inspect(robot.brain.data, false, 4)
+
+        collection.save robot.brain.data, (err) ->
+          console.warn err if err?


### PR DESCRIPTION
This updates the current mongo brain to use merge instead of overwrite for the brain loading.  We can switch the brain out for a smarter one without losing everything :smile: 

Relevant diff:

``` diff
--- ../hubot-scripts/src/scripts/mongo-brain.coffee 2014-03-21 15:33:20.000000000 -0700
+++ scripts/mongo-brain.coffee  2014-04-16 11:41:07.000000000 -0700
@@ -58,7 +58,7 @@
         robot.logger.debug Util.inspect(results, false, 4)

         if results.length > 0
-          robot.brain.data = results[0]
+          robot.brain.mergeData results[0]
           robot.brain.emit 'loaded', results[0]
         else
           robot.logger.debug 'No results found'
```

Tagging @doomspork / @jmacadam for review
