### PR TITLE
Add 46elks sms, which has phone number saving built in

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,4 +1,5 @@
 [
+  "46elks.coffee",
   "ackbar.coffee",
   "applause.coffee",
   "availability.coffee",


### PR DESCRIPTION
This adds support for 46elks, which allows sending SMSes.  But it also has built in support for tracking phone numbers for users.

```
Hubot> hubot shell has phone number 36632325
Hubot> Ok, shell has phone 36632325.
Hubot> hubot give me the phone number to shell
Hubot> Shell has phone number 36632325.
Hubot> hubot shell has phone number 36632325
Hubot> I know.
```

Source script: [46elks.coffee](https://github.com/github/hubot-scripts/blob/master/src/scripts/46elks.coffee)
Tagging @doomspork / @jmacadam for review
