### PR TITLE
Add the mongolab brain, for migrating purposes

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -10,6 +10,7 @@
   "hello.coffee",
   "kittens.coffee",
   "lolz.coffee",
+  "mongolab-brain.coffee",
   "pagerduty.coffee",
   "shipit.coffee",
   "snow.coffee",


### PR DESCRIPTION
Adds a more hipchat-capable version of the mongo brain.  In my testing, this should be fine, we'll "merge" the data "from" this new empty db, which will have no IDs.  The current data will then be loaded into the new brain, we'll have another PR to remove the other brain.

Tagging @doomspork / @jmacadam for review
