### PR TITLE
Switch to alternative adapter to fix mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bson":                "*",
     "htmlparser":          "*",
     "hubot":               ">= 2.6.0 < 3.0.0",
-    "hubot-hipchat":       "2.5.1-5",
+    "hubot-hipchat":       "https://github.com/liftopia/hubot-hipchat/archive/fix-roster-updates.tar.gz",
     "hubot-plusplus":      "1.0.x",
     "hubot-scripts":       ">= 2.5.0 < 3.0.0",
     "moment":              "1.6.2",


### PR DESCRIPTION
The current hipchat adapter has trouble picking up the mentions and saving new users correctly. Someone already did the work, I forked it, trimmed it, and prepped it, so here it is :smile: 

Here's the differences (https://github.com/liftopia/hubot-hipchat/compare/fix-roster-updates):

``` diff
diff --git a/src/hipchat.coffee b/src/hipchat.coffee
index e4b1890..9c6d490 100644
--- a/src/hipchat.coffee
+++ b/src/hipchat.coffee
@@ -91,9 +91,10 @@ class HipChat extends Adapter
         for user in users
           user.id = @userIdFromJid user.jid
           # userForId will not overwrite an existing user
-          if user.id of @robot.brain.data.users
+          if user.id in @robot.brain.data.users
             delete @robot.brain.data.users[user.id]
           @robot.brain.userForId user.id, user
+          @robot.brain.data.users[user.id]['mention_name'] = user.mention_name

       # Fetch user info
       connector.getRoster (err, users, stanza) =>
```
