### PR TITLE
Replace githubot with a better github library

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bson":                "*",
     "dateformat":          "*",
     "fixed-array":         "1.0.0",
-    "githubot":            "0.5.x",
+    "github":              "0.1.16",
     "htmlparser":          "*",
     "hubot":               ">= 2.6.0 < 3.0.0",
     "hubot-hipchat":       "https://github.com/liftopia/hubot-hipchat/archive/fix-roster-updates.tar.gz",


### PR DESCRIPTION
`githubot` is interesting, but not very useful, especially if there's issues that occur from the github api itself.  Replaced it with the `github` library, which provides more robust callback functionality for errors.

I have an idea for how to switch the github components out with an event based system, which should clean this up quite a bit.

Tagging @Drewzar for review
