### PR TITLE
Use a greedier regex for updating users

### DIFF
--- a/scripts/manage-users.coffee
+++ b/scripts/manage-users.coffee
@@ -49,7 +49,7 @@ module.exports = (robot) ->
     value = msg.match[3]
 
     if is_allowed msg, id
-      if field in [ 'id', 'jid', 'name' ]
+      if field in [ 'id', 'name' ]
         msg.send "Don't even try to update #{field}"
       else
         robot.brain.data['users'][id][field] = value


### PR DESCRIPTION
Right now, updating a user's field regexes on word characters, so `@` and `.` don't work.  This means updating email addresses or jabber ids doesn't work.

Specifically, trying to do this fails with the current regex:

```
jarvis update user 123456 jid 12345_123456@chat.hipchat.com
```

Tagging @Drewzar for reivew.
