### PR TITLE
adding the victorops script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "hubot-hipchat":       "https://github.com/liftopia/hubot-hipchat/archive/fix-roster-updates.tar.gz",
     "hubot-plusplus":      "1.0.x",
     "hubot-scripts":       ">= 2.5.0 < 3.0.0",
+    "hubot-victorops":     ">=0.0.2",
     "jenkins":             "*",
     "moment":              "1.6.2",
     "mongodb":             "1.3.11",


### PR DESCRIPTION
Adding the VictorOps script, also added the API key to heroku and added the On Call room to `HUBOT_HIPCHAT_ROOMS`.

Think we should remove him from `13693_joshs_playroom@conf.hipchat.com`?
