### PR TITLE
adding stathat to mark deploys and branchs

### DIFF
--- a/scripts/deploy-lock.coffee
+++ b/scripts/deploy-lock.coffee
@@ -25,6 +25,7 @@
 #   hubot deployment history - List the last deployments
 #   hubot remove active deploy - Remove the currently active deploy in case of disappearance
 #   hubot cancel (my|<name>) deploys - Remove all deploys for target
+#   hubot deploy failed - Mark the deploy as failed in stathat
 #
 # Author:
 #   amdtech
@@ -557,6 +558,18 @@ module.exports = (robot) ->
   # Some feedback on bad requests
   robot.respond /i(?:'m)?\s*next\s*([\w\.]+)$/i, (msg) ->
     msg.send "You need to tell me the PR you're deploying! (i'm next " + msg.match[1] + " <pr#>)"
+
+  robot.respond /deploy failed/i, (msg) ->
+    active   = deployers.active()
+    history  = deployers.history()
+
+    if active?
+      msg.send "Active deploy marked as failed."
+      robot.emit 'stathat:mark:deployFailed', active, msg
+    else
+      msg.send "Marking last deploy as failed."
+      robot.emit 'stathat:mark:deployFailed', history.slice(0).reverse()[0], msg
+
 
   topic_handler = (details) ->
     msg = details.msg

--- a/scripts/deployer.coffee
+++ b/scripts/deployer.coffee
@@ -369,15 +369,17 @@ module.exports = (robot) ->
   # Destroy a feature server
   robot.respond /destroy (.+)/i, (msg) ->
     destroy msg
+    robot.emit 'stathat:mark:branchDestroy', msg
 
   # Deploy using the previous options
   robot.respond /redeploy (.+)/i, (msg) ->
     redeploy msg
 
   # Deploy our feature server
-  robot.respond /deploy (.+)/i, (msg) ->
+  robot.respond /deploy ((?!failed$).+)/i, (msg) ->
     whom = from_who msg
     deploy msg
+    robot.emit 'stathat:mark:branchCreate', msg
 
   # List all known deployments
   robot.respond /(?:list|get)?\s?deployments/i, (msg) ->
@@ -487,4 +489,3 @@ module.exports = (robot) ->
     catch error
       console.log "jenkins-notify error: #{error}. Data: #{req.body}"
       console.log error.stack
-

--- a/scripts/stathat.coffee
+++ b/scripts/stathat.coffee
@@ -2,7 +2,7 @@
 #   Stathat stat poster
 #
 # Dependencies:
-#   underscore
+#   
 #
 # Configuration:
 #   HUBOT_STATHAT_KEY

--- a/scripts/stathat.coffee
+++ b/scripts/stathat.coffee
@@ -1,0 +1,51 @@
+# Description:
+#   Stathat stat poster
+#
+# Dependencies:
+#   underscore
+#
+# Configuration:
+#   HUBOT_STATHAT_KEY
+#
+# Commands:
+#   N/A
+#
+# Author:
+#   drewzarr
+
+stathat_key = process.env.HUBOT_STATHAT_KEY
+
+module.exports = (robot) ->
+  # Mark failed deploys
+  robot.on 'stathat:mark:deployFailed', (manifest, msg) ->
+    repo = repo
+    data = JSON.stringify({
+      "ezkey": "#{stathat_key}"
+      "data": [
+        {"stat" : "#{manifest.repo} failed deploys", "count" : 1},
+        {"stat" : "#{manifest.repo} deploys", "count" : -1}
+      ]
+      })
+
+    robot.http("http://api.stathat.com/ez")
+      .header('Content-Type', 'application/json')
+      .post(data) (err, res, body) ->
+        msg.send "Error running job :( #{err}" if err
+
+  # Mark Branch Creation
+  robot.on 'stathat:mark:branchCreate', (msg) ->
+    data = "stat=Branch Created&email=#{stathat_key}&count=1"
+
+    robot.http("http://api.stathat.com/ez")
+      .header('Content-Type', 'application/x-www-form-urlencoded')
+      .post(data) (err, res, body) ->
+        msg.send "Error running job :( #{err}" if err
+
+  # Mark branch destorys
+  robot.on 'stathat:mark:branchDestroy', (msg) ->
+    data = "stat=Branch Destroyed&email=#{stathat_key}&count=1"
+
+    robot.http("http://api.stathat.com/ez")
+      .header('Content-Type', 'application/x-www-form-urlencoded')
+      .post(data) (err, res, body) ->
+        msg.send "Error running job :( #{err}" if err


### PR DESCRIPTION
Adding a new jarvis command:

`jarvis deploy failed` 

If a deploy is active it will mark the currently active as failed. If there's no deploy active it will mark the last deploy as failed. This will also NOT create a branch box. 

Bonus, now tracking branch box creations and deletions. 