### PR TITLE
Update hipchat adapter to the latest npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "hubot":                  "2.11.1",
     "hubot-calculator":       "0.3.0",
     "hubot-heroku-keepalive": "0.0.4",
-    "hubot-hipchat":          "https://github.com/liftopia/hubot-hipchat/archive/fix-roster-updates.tar.gz",
+    "hubot-hipchat":          "~2.12",
     "hubot-plusplus":         "1.0.x",
     "hubot-scripts":          ">= 2.5.0 < 3.0.0",
     "jenkins":                "*",


### PR DESCRIPTION
We've been using our own version of the hipchat adapter to resolve an issue with roster updates. While I'm not entirely convinced the public version will work, there's been a lot of changes that are necessary to keep jarvis up and running.

If ultimately we find that roster updates are still broken, we'll re-patch and see if upstream wants it.

Tagging @Drewzar for review.