### PR TITLE
piggy_bank deploys going to rundeck

### DIFF
--- a/scripts/deploy-lock.coffee
+++ b/scripts/deploy-lock.coffee
@@ -336,7 +336,6 @@ get_plan = (string) ->
 # Add our new functionality to Hubot!
 module.exports = (robot) ->
   release_url     = process.env.JENKINS_RELEASE_URL
-  production_job  = process.env.JENKINS_PRODUCTION_JOB
   rtopia_job      = 'ReleaseRtopia'
   repos           = {}
 
@@ -535,12 +534,10 @@ module.exports = (robot) ->
     params[repos[manifest.repo]] = manifest.branch
     params["Confirmed"]          = "true"
 
-    if manifest.repo == 'liftopia.com'
+    if manifest.repo == 'liftopia.com' || manifest.repo == 'piggy_bank'
       robot.emit 'rundeck:run', manifest, msg
-    else if manifest.repo == 'rtopia'
+    else # rtopia
       robot.emit 'jenkins:build', rtopia_job, params, msg
-    else
-      robot.emit 'jenkins:build', production_job, params, msg
 
     topic_handler details
 


### PR DESCRIPTION
This moves the piggy_bank deploy job directly to rundeck.

**Before Deploying**
We need to update the `HUBOT_RUNDECK_JIDS` to include the piggy_bank rundeck job.

cc @amdtech 