### PR TITLE
deploying ember apps

### DIFF
--- a/scripts/deploy-lock.coffee
+++ b/scripts/deploy-lock.coffee
@@ -337,6 +337,7 @@ get_plan = (string) ->
 module.exports = (robot) ->
   release_url     = process.env.JENKINS_RELEASE_URL
   rtopia_job      = 'ReleaseRtopia'
+  ember_job       = 'DeployEmberApp'
   repos           = {}
 
   _.each process.env.HUBOT_REPOS_LOOKUP?.split(','), (details) ->
@@ -536,8 +537,10 @@ module.exports = (robot) ->
 
     if manifest.repo == 'liftopia.com' || manifest.repo == 'piggy_bank'
       robot.emit 'rundeck:run', manifest, msg
-    else # rtopia
+    else if manifest.repo == 'rtopia'
       robot.emit 'jenkins:build', rtopia_job, params, msg
+    else # EmberApps
+      robot.emit 'jenkinsio:build', ember_job, params, msg
 
     topic_handler details
 

--- a/scripts/jenkinsio.coffee
+++ b/scripts/jenkinsio.coffee
@@ -1,0 +1,28 @@
+# Description:
+#   Jenkins Build Manager
+#
+# Dependencies:
+#   jenkins
+#
+# Configuration:
+#   HUBOT_JENKINS_TOKEN
+#   HUBOT_JENKINS_URL
+#
+# Commands:
+#   N/A
+#
+# Author:
+#   amdtech
+
+jenkins = require('jenkins')(process.env.HUBOT_JENKINSIO_URL)
+
+module.exports = (robot) ->
+  token = process.env.HUBOT_JENKINS_TOKEN
+
+  robot.on 'jenkinsio:build', (job, params, msg) ->
+    jenkins.job.build job, { token: token, parameters: params }, (err) ->
+      # to get around a jenkins bug in the version we're running
+      if err?.res?.statusCode != 302
+        callback?(err)
+      else
+        callback?()


### PR DESCRIPTION
I'm sure there are more DRY methods than this, but this is a quick and easy way to get deploys rolling through `build.io`.

We can clean this up when we move the prod deploys to dot.

**Before Deploying** Need to set `HUBOT_JENKINSIO_URL`