### PR TITLE
don't pass any repo to jenkins

### DIFF
--- a/scripts/deploy-lock.coffee
+++ b/scripts/deploy-lock.coffee
@@ -544,8 +544,8 @@ module.exports = (robot) ->
       robot.emit 'jenkins:build', rtopia_job, params, msg
     else if manifest.repo == 'cloudstore_client'
       robot.emit 'jenkinsio:build', cloudstore_job, params, msg
-    else # core_client
-      robot.emit 'jenkinsio:build', core_job, params, msg
+    else
+      msg.send "I can't deploy that repo"
 
     topic_handler details
 


### PR DESCRIPTION
This removes the ability to pass any known repo in to hubot and have it passed on to jenkins. 
Bonus, cleaned up some old core_client stuff 👍 

cc @liftopia/engineering 